### PR TITLE
SNAP-14357 Add elm debugger to all builds for the dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 _We currently use it for our builds to avoid warnings about deprecated dependencies in the last parcel@1.12.4 release (2019)_
 
+Given the environment variable `SNAPVIEW_ENV=dev`, the elm debugger will be active for builds.
+
 ---
 
 <p align="center">
@@ -46,9 +48,9 @@ npm install -g parcel-bundler
 
 ```html
 <html>
-<body>
-  <script src="./index.js"></script>
-</body>
+  <body>
+    <script src="./index.js"></script>
+  </body>
 </html>
 ```
 

--- a/packages/core/parcel-bundler/src/assets/ElmAsset.js
+++ b/packages/core/parcel-bundler/src/assets/ElmAsset.js
@@ -71,6 +71,16 @@ class ElmAsset extends Asset {
   }
 
   async generate() {
+    // SNAP-14375 Add --debug to elm compiler for dev environment builds
+    switch (process.env.SNAPVIEW_ENV ?? '') {
+      case 'dev':
+        this.elmOpts.debug = true;
+        this.elmOpts.optimize = false;
+        break;
+      default:
+        break;
+    }
+
     let compiled = await this.elm.compileToString(this.name, this.elmOpts);
     this.contents = compiled.toString();
     if (this.options.hmr) {


### PR DESCRIPTION
We use the `SNAPVIEW_ENV` environment variable to enable the elm debugger in deployments on our dev environment.
